### PR TITLE
feat: add secured available-actions endpoint

### DIFF
--- a/api/src/logic/connection_definition.rs
+++ b/api/src/logic/connection_definition.rs
@@ -405,18 +405,8 @@ pub struct AvailableConnectorsResponse {
     pub image: String,
     pub tags: Vec<String>,
     pub oauth: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub actions: Option<Vec<ActionItem>>,
     #[serde(flatten)]
     pub record_metadata: RecordMetadata,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ActionItem {
-    pub title: String,
-    pub key: String,
-    #[serde(with = "http_serde_ext_ios::method")]
-    pub method: http::Method,
 }
 
 pub async fn get_available_connectors(
@@ -424,22 +414,7 @@ pub async fn get_available_connectors(
     query: Option<Query<BTreeMap<String, String>>>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<ServerResponse<ReadResponse<AvailableConnectorsResponse>>>, PicaError> {
-    let mut query_params = query.clone().map(|q| q.0).unwrap_or_default();
-
-    let include_actions = query_params
-        .get("includeActions")
-        .map(|v| v.to_lowercase() == "true")
-        .unwrap_or(false);
-
-    query_params.remove("includeActions");
-
-    let filtered_query = if !query_params.is_empty() {
-        Some(Query(query_params))
-    } else {
-        None
-    };
-
-    let query = shape_mongo_filter(filtered_query, None, Some(headers));
+    let query = shape_mongo_filter(query, None, Some(headers));
 
     let store = state.app_stores.connection_config.clone();
 
@@ -456,45 +431,9 @@ pub async fn get_available_connectors(
 
     let res = match try_join!(count, find) {
         Ok((total, rows)) => {
-            let mut available_connectors = Vec::with_capacity(rows.len());
-
-            for conn_def in rows {
-                let actions = if include_actions {
-                    let model_definitions = state
-                        .app_stores
-                        .model_config
-                        .get_many(
-                            Some(doc! {
-                                "connectionPlatform": &conn_def.platform,
-                                "supported": true,
-                                "deleted": false
-                            }),
-                            None,
-                            None,
-                            None,
-                            None,
-                        )
-                        .await
-                        .map_err(|e| {
-                            error!("Error reading from connection model definitions: {e}");
-                            e
-                        })?;
-
-                    let action_items = model_definitions
-                        .into_iter()
-                        .map(|model_def| ActionItem {
-                            title: model_def.title,
-                            key: model_def.name,
-                            method: model_def.action,
-                        })
-                        .collect();
-
-                    Some(action_items)
-                } else {
-                    None
-                };
-
-                available_connectors.push(AvailableConnectorsResponse {
+            let available_connectors = rows
+                .into_iter()
+                .map(|conn_def| AvailableConnectorsResponse {
                     name: conn_def.name,
                     key: conn_def.key,
                     platform_version: conn_def.platform_version,
@@ -503,10 +442,9 @@ pub async fn get_available_connectors(
                     image: conn_def.frontend.spec.image,
                     tags: conn_def.frontend.spec.tags,
                     oauth: matches!(conn_def.auth_method, Some(AuthMethod::OAuth)),
-                    actions,
                     record_metadata: conn_def.record_metadata,
-                });
-            }
+                })
+                .collect();
 
             ReadResponse {
                 rows: available_connectors,

--- a/api/src/logic/connection_definition.rs
+++ b/api/src/logic/connection_definition.rs
@@ -459,5 +459,5 @@ pub async fn get_available_connectors(
         }
     };
 
-    Ok(Json(ServerResponse::new("connection_definition", res)))
+    Ok(Json(ServerResponse::new("Available Connectors", res)))
 }

--- a/api/src/logic/connection_model_definition.rs
+++ b/api/src/logic/connection_model_definition.rs
@@ -500,8 +500,5 @@ pub async fn get_available_actions(
         }
     };
 
-    Ok(Json(ServerResponse::new(
-        "connection_model_definition",
-        res,
-    )))
+    Ok(Json(ServerResponse::new("Available Actions", res)))
 }

--- a/api/src/logic/connection_model_definition.rs
+++ b/api/src/logic/connection_model_definition.rs
@@ -1,17 +1,18 @@
-use super::{create, delete, read, update, HookExt, PublicExt, RequestExt};
+use super::{create, delete, read, update, HookExt, PublicExt, ReadResponse, RequestExt};
 use crate::{
+    helper::shape_mongo_filter,
     router::ServerResponse,
     server::{AppState, AppStores},
 };
 use axum::{
+    extract::Query,
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     routing::{patch, post},
     Extension, Json, Router,
 };
 use chrono::Utc;
 use fake::Dummy;
-use http::HeaderMap;
 use mongodb::bson::doc;
 use osentities::{
     algebra::MongoStore,
@@ -33,6 +34,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
 };
+use tokio::try_join;
 use tracing::error;
 
 pub fn get_router() -> Router<Arc<AppState>> {
@@ -437,4 +439,69 @@ impl RequestExt for CreateRequest {
     fn get_store(stores: AppStores) -> MongoStore<Self::Output> {
         stores.model_config.clone()
     }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ActionItem {
+    pub title: String,
+    pub key: String,
+    #[serde(with = "http_serde_ext_ios::method")]
+    pub method: http::Method,
+    pub platform: String,
+}
+
+pub async fn get_available_actions(
+    headers: HeaderMap,
+    Path(platform): Path<String>,
+    query: Option<Query<BTreeMap<String, String>>>,
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<ServerResponse<ReadResponse<ActionItem>>>, PicaError> {
+    let query = shape_mongo_filter(query, None, Some(headers));
+
+    let mut filter = query.filter;
+    filter.insert("connectionPlatform", platform.clone());
+    filter.insert("supported", true);
+
+    let store = state.app_stores.model_config.clone();
+
+    let count_filter = filter.clone();
+    let count = store.count(count_filter, None);
+
+    let find = store.get_many(
+        Some(filter),
+        None,
+        None,
+        Some(query.limit),
+        Some(query.skip),
+    );
+
+    let res = match try_join!(count, find) {
+        Ok((total, rows)) => {
+            let action_items = rows
+                .into_iter()
+                .map(|model_def| ActionItem {
+                    title: model_def.title,
+                    key: model_def.name,
+                    method: model_def.action,
+                    platform: model_def.connection_platform,
+                })
+                .collect();
+
+            ReadResponse {
+                rows: action_items,
+                skip: query.skip,
+                limit: query.limit,
+                total,
+            }
+        }
+        Err(e) => {
+            error!("Error reading from store: {e}");
+            return Err(e);
+        }
+    };
+
+    Ok(Json(ServerResponse::new(
+        "connection_model_definition",
+        res,
+    )))
 }

--- a/api/src/router/secured_key.rs
+++ b/api/src/router/secured_key.rs
@@ -1,7 +1,7 @@
 use crate::{
     logic::{
         connection, connection_definition,
-        connection_model_definition::test_connection_model_definition,
+        connection_model_definition::{get_available_actions, test_connection_model_definition},
         connection_model_schema::{
             public_get_connection_model_schema, PublicGetConnectionModelSchema,
         },
@@ -59,7 +59,8 @@ pub async fn get_router(state: &Arc<AppState>) -> Router<Arc<AppState>> {
         .route(
             "/available-connectors",
             get(connection_definition::get_available_connectors),
-        );
+        )
+        .route("/available-actions/:platform", get(get_available_actions));
 
     let routes = match RateLimiter::from_state(state.clone()).await {
         Ok(rate_limiter) => routes.layer(axum::middleware::from_fn_with_state(


### PR DESCRIPTION
Removes the `includeActions` option from the `/available-connectors` endpoint and add a new endpoint for `/available-actions`.