### PR TITLE
feat: LinkedIn OAuth

### DIFF
--- a/oauth/src/connections/linkedIn/init.ts
+++ b/oauth/src/connections/linkedIn/init.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { DataObject, OAuthResponse } from '../../lib/types';
+
+export const init = async ({ body }: DataObject): Promise<OAuthResponse> => {
+    try {
+        const {
+            clientId: client_id,
+            clientSecret: client_secret,
+            metadata: { code, redirectUri: redirect_uri } = {},
+        } = body;
+
+        const data = {
+            client_id,
+            client_secret,
+            code,
+            redirect_uri,
+            grant_type: 'authorization_code',
+        };
+
+        const response = await axios({
+            url: 'https://www.linkedin.com/oauth/v2/accessToken',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            data,
+        });
+
+        const {
+            data: { access_token: accessToken, expires_in: expiresIn, scope },
+        } = response;
+
+        return {
+            accessToken,
+            refreshToken: accessToken,
+            expiresIn,
+            tokenType: 'Bearer',
+            meta: {
+                scope,
+            },
+        };
+    } catch (error) {
+        throw new Error(`Error fetching access token for LinkedIn: ${error}`);
+    }
+};

--- a/oauth/src/connections/linkedIn/refresh.ts
+++ b/oauth/src/connections/linkedIn/refresh.ts
@@ -1,0 +1,27 @@
+import { DataObject, OAuthResponse } from '../../lib/types';
+
+export const refresh = async ({ body }: DataObject): Promise<OAuthResponse> => {
+    try {
+        const {
+            OAUTH_METADATA: {
+                accessToken,
+                refreshToken,
+                expiresIn,
+                tokenType,
+                meta: { scope },
+            },
+        } = body;
+
+        return {
+            accessToken,
+            refreshToken,
+            expiresIn,
+            tokenType,
+            meta: {
+                scope,
+            },
+        };
+    } catch (error) {
+        throw new Error(`Error fetching refresh token for LinkedIn: ${error}`);
+    }
+};


### PR DESCRIPTION
# Notes
- LinkedIn doesn't have a refresh token flow natively available. The access token expires after 2 months. The customers will need to re-add the connection after every 2 months.
